### PR TITLE
[Recipient Management]: Fixed bug to join groups <> members in a table, displaying groups members are a part of in the table

### DIFF
--- a/app/members/page.tsx
+++ b/app/members/page.tsx
@@ -20,27 +20,47 @@ export default async function Members() {
     status,
   } = await supabase.from("members").select("*").eq("created_by", user.id);
 
-  // const {
-  //   data: members,
-  //   error,
-  //   status,
-  // } = await supabase
-  //   .from("members")
-  //   .select(
-  //     `
-  //       id,
-  //       email,
-  //       first_name,
-  //       last_name,
-  //       created_at,
-  //       created_by,
-  //       member_groups:group (
-  //         id,
-  //         name
-  //       )
-  //     `
-  //   )
-  //   .eq("created_by", user.id);
+  // Fetch group information
+  const { data: groupMappings, error: groupError } = await supabase
+    .from("member_group_joins")
+    .select("member_id, group_id");
+
+  if (error || groupError) {
+    console.error("Error fetching data:", error || groupError);
+  }
+
+  // Create a mapping of member IDs to an array of group IDs
+  const memberGroupInfo: Record<string, string[]> = {};
+  groupMappings?.forEach((groupJoin) => {
+    const memberId = groupJoin.member_id;
+    const groupId = groupJoin.group_id;
+    if (!memberGroupInfo[memberId]) {
+      memberGroupInfo[memberId] = [];
+    }
+    memberGroupInfo[memberId].push(groupId);
+  });
+
+  type GroupName = {
+    id: string;
+    name: string;
+  };
+  let groupNamesData: GroupName[] = [];
+
+  if (groupMappings) {
+    const groupIds: string[] = groupMappings.map((mapping) => mapping.group_id);
+    const { data: groupNamesResponse, error: groupNamesError } = await supabase
+      .from("member_groups")
+      .select("id, name")
+      .in("id", groupIds);
+
+    if (groupNamesResponse) {
+      groupNamesData = groupNamesResponse;
+    } else {
+      groupNamesData = [];
+    }
+  }
+
+  console.log("groupmappings", groupNamesData, groupMappings);
 
   return (
     <div className="flex-1 space-y-4 p-8 pt-6">
@@ -51,7 +71,11 @@ export default async function Members() {
         </div>
       </div>
       <div className="flex">
-        <MembersTable members={members!} />
+        <MembersTable
+          members={members!}
+          groupMappings={memberGroupInfo}
+          groupNamesData={groupNamesData}
+        />
       </div>
     </div>
   );

--- a/components/add-member.tsx
+++ b/components/add-member.tsx
@@ -45,7 +45,7 @@ export default function AddMemberForm({ user }: { user: any }) {
   const supabase = createClientComponentClient();
   const [memberGroups, setMemberGroups] = React.useState<MemberGroup[]>([]); // State to store member groups
   const [selectedGroups, setSelectedGroups] =
-    React.useState<MultiValue<string> | null>(null); // State to track selected group
+    React.useState<MultiValue<number> | null>(null); // State to track selected group
   const [open, setOpen] = React.useState(false);
   const router = useRouter();
   const form = useForm<MemberFormValues>({
@@ -80,6 +80,7 @@ export default function AddMemberForm({ user }: { user: any }) {
     try {
       let groupIds = null;
 
+      console.log("memberGroups", memberGroups);
       // Check if the selectedGroups exists in memberGroups
       const newGroups =
         selectedGroups
@@ -91,7 +92,7 @@ export default function AddMemberForm({ user }: { user: any }) {
 
       console.log("newgroups", newGroups);
 
-      groupIds = selectedGroups?.map((group) => group.value);
+      // groupIds = selectedGroups?.map((group) => group.value);
 
       // If selectedGroups doesn't exist, create a new group
       if (!!newGroups.length) {
@@ -129,12 +130,23 @@ export default function AddMemberForm({ user }: { user: any }) {
       }
       const memberID = newMember[0].id;
 
+      console.log("SELECT", selectedGroups);
+
       // Update the joins table to associate the member with the group
-      if (!!groupIds?.length && memberID) {
-        const joinUpdates = groupIds.map((groupId) => ({
-          member_id: memberID,
-          group_id: groupId,
-        }));
+      if (!!selectedGroups?.length && memberID) {
+        const joinUpdates = memberGroups
+          ?.filter((memberGroup) =>
+            selectedGroups
+              .map((selectedGroup) => selectedGroup.value)
+              .includes(memberGroup.name)
+          )
+          .map(({ id }) => id)
+          .concat(groupIds)
+          .map((memberGroupId) => ({
+            member_id: memberID,
+            group_id: memberGroupId,
+          }));
+
         const { error: joinError } = await supabase
           .from("member_group_joins")
           .insert(joinUpdates);

--- a/components/add-member.tsx
+++ b/components/add-member.tsx
@@ -91,6 +91,8 @@ export default function AddMemberForm({ user }: { user: any }) {
 
       console.log("newgroups", newGroups);
 
+      groupIds = selectedGroups?.map((group) => group.value);
+
       // If selectedGroups doesn't exist, create a new group
       if (!!newGroups.length) {
         const groupResponse = await supabase

--- a/components/members-table.tsx
+++ b/components/members-table.tsx
@@ -20,11 +20,26 @@ import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import { toast } from "./ui/use-toast";
 import { useRouter } from "next/navigation";
 import EditMemberForm from "./edit-member";
+import { useEffect, useState } from "react";
 
 type Member = Database["public"]["Tables"]["members"]["Row"];
+type GroupMappings = Record<string, string[]>;
+type GroupName = {
+  id: number;
+  name: string;
+};
 
-export function MembersTable({ members }: { members: Member[] }) {
+export function MembersTable({
+  members,
+  groupMappings,
+  groupNamesData,
+}: {
+  members: Member[];
+  groupMappings: GroupMappings;
+  groupNamesData: GroupName;
+}) {
   const supabase = createClientComponentClient();
+  const [groupInfo, setGroupInfo] = useState({});
 
   const router = useRouter();
 
@@ -41,6 +56,7 @@ export function MembersTable({ members }: { members: Member[] }) {
     }
   }
 
+  console.log("members", members);
   return (
     <Table>
       <TableHeader>
@@ -48,6 +64,7 @@ export function MembersTable({ members }: { members: Member[] }) {
           <TableHead className="w-[100px]">Name</TableHead>
           <TableHead>Email</TableHead>
           <TableHead>Created Time</TableHead>
+          <TableHead>Group</TableHead>
         </TableRow>
       </TableHeader>
       <TableBody>
@@ -60,6 +77,21 @@ export function MembersTable({ members }: { members: Member[] }) {
             <TableCell>
               {new Date(member.created_at).toLocaleString("en-US")}
             </TableCell>
+            {groupMappings[member.id]
+              ? groupMappings[member.id]
+                  .map((groupId) => {
+                    const matchingGroup = groupNamesData.find(
+                      (group) => group.id === groupId
+                    ) as GroupName;
+                    if (matchingGroup) {
+                      return matchingGroup.name;
+                    }
+                    return null;
+                  })
+                  .join(", ")
+              : "No Groups"}
+            {/* This will log the member object */}
+            {/* <TableCell>{member}</TableCell> */}
             <TableCell>
               <TooltipProvider>
                 <Tooltip>

--- a/components/members-table.tsx
+++ b/components/members-table.tsx
@@ -77,21 +77,23 @@ export function MembersTable({
             <TableCell>
               {new Date(member.created_at).toLocaleString("en-US")}
             </TableCell>
-            {groupMappings[member.id]
-              ? groupMappings[member.id]
-                  .map((groupId) => {
-                    const matchingGroup = groupNamesData.find(
-                      (group) => group.id === groupId
-                    ) as GroupName;
-                    if (matchingGroup) {
-                      return matchingGroup.name;
-                    }
-                    return null;
-                  })
-                  .join(", ")
-              : "No Groups"}
-            {/* This will log the member object */}
-            {/* <TableCell>{member}</TableCell> */}
+
+            <TableCell>
+              {groupMappings[member.id]
+                ? groupMappings[member.id]
+                    .map((groupId) => {
+                      const matchingGroup = groupNamesData.find(
+                        (group) => group.id === groupId
+                      ) as GroupName;
+                      if (matchingGroup) {
+                        return matchingGroup.name;
+                      }
+                      return null;
+                    })
+                    .join(", ")
+                : "None"}
+            </TableCell>
+
             <TableCell>
               <TooltipProvider>
                 <Tooltip>


### PR DESCRIPTION
<img width="1174" alt="image" src="https://github.com/alanagoyal/rebase/assets/31157307/a3e53038-7c43-4e39-a37e-d13c12aa6876">

Lol please ignore the names I used for the test users 😅. When you click on the members page, it shows the group they're part of in the table.

Now all the entries are showing up in the `member_group_joins` table. (You can see that multiple member ids are repeated - which means one member is associated to different groups!)
<img width="541" alt="image" src="https://github.com/alanagoyal/rebase/assets/31157307/b173f375-8777-4b86-904f-6ac834ff11b7">

Closes: https://github.com/alanagoyal/rebase/issues/16  and https://github.com/alanagoyal/rebase/issues/13 and https://github.com/alanagoyal/rebase/issues/22